### PR TITLE
Adding scoverage compatability

### DIFF
--- a/src/main/scala/directive/Generate.scala
+++ b/src/main/scala/directive/Generate.scala
@@ -8,14 +8,13 @@ import DirectiveKeys._
 object Generate {
 
   val task = Def.task {
-    run(streams.value.log, 
-      dependencyClasspath.value,
+    run(dependencyClasspath.value,
       preprocessors.value.toList,
       target.value
     )
   }
 
-  private def run(log: Logger, 
+  private def run(
     cp: Classpath,
     preprocessors: List[DeferredPreprocessor],
     target: File): File = {

--- a/src/main/scala/directive/Plugin.scala
+++ b/src/main/scala/directive/Plugin.scala
@@ -20,8 +20,7 @@ object DirectivePlugin extends AutoPlugin {
       directiveScala := Run.scala.value,
       directiveJava := Run.java.value,
       scalaSource := baseDirectory.value / "src" / "main" / "scala",
-      javaSource := baseDirectory.value / "src" / "main" / "java",
-      generatedSourceDir := target.value / "directive" / "generatedSources"
+      javaSource := baseDirectory.value / "src" / "main" / "java"
     )) ++ 
     Seq(
       preprocessors := Seq.empty,
@@ -29,6 +28,7 @@ object DirectivePlugin extends AutoPlugin {
       (sourceGenerators in Compile) <+= (directiveJava in Directive),
       (scalaSource in Compile) := target.value / "directive" / "empty",
       (javaSource in Compile) := target.value / "directive" / "empty",
+      (sourceDirectories in Compile) += (sourceManaged in Directive).value,
       ivyConfigurations += Directive,
       libraryDependencies ++= Seq(
         "sbt-directive" %% "cli" % "0.0.1-SNAPSHOT" % Directive,
@@ -40,7 +40,6 @@ object DirectivePlugin extends AutoPlugin {
 
 object DirectiveKeys {
 
-  val generatedSourceDir: SettingKey[File] = settingKey("directory containing generated sources")
   val preprocessors: SettingKey[Seq[DeferredPreprocessor]] = settingKey("preprocessor directives")
   val generate: TaskKey[File] = taskKey("generates and compiles a synthetic main")
   val directiveScala: TaskKey[Seq[File]] = taskKey("Runs preprocessors on scala sources")

--- a/src/main/scala/directive/Run.scala
+++ b/src/main/scala/directive/Run.scala
@@ -9,14 +9,21 @@ import DirectiveKeys._
 object Run {
 
   val scala = Def.task {
-    run(streams.value.log, dependencyClasspath.value, generate.value, "*.scala" ,scalaSource.value, generatedSourceDir.value)
+    run(streams.value.log, dependencyClasspath.value, generate.value, "*.scala" ,scalaSource.value,
+      sourceManaged.value)
   }
 
   val java = Def.task {
-    run(streams.value.log, dependencyClasspath.value, generate.value, "*.java", javaSource.value, generatedSourceDir.value)
+    run(streams.value.log, dependencyClasspath.value, generate.value, "*.java", javaSource.value,
+      sourceManaged.value)
   }
 
   private def run(log: Logger, cp: Classpath, main: File, pattern: String, source: File, dest: File): Seq[File] = {
+
+    log.info(s"Generating processed sources in $dest")
+
+    dest.mkdirs
+
     val options = ForkOptions(
       bootJars = cp.files :+ main,
       outputStrategy = Some(StdoutOutput)

--- a/src/main/scala/directive/preprocess.scala
+++ b/src/main/scala/directive/preprocess.scala
@@ -17,7 +17,7 @@ object Preprocess {
     }
 
   def skip(tag: String): DeferredPreprocessor =
-    lines(tag)("_ => List.empty")
+    lines(tag)(s"""_.map(_ => "" )""")
 
   def identity(tag: String): DeferredPreprocessor =
     lines(tag)("identity")

--- a/src/sbt-test/sbt-directive/basic/checkEmpty.sbt
+++ b/src/sbt-test/sbt-directive/basic/checkEmpty.sbt
@@ -4,7 +4,7 @@ val checkEmpty = InputKey[Unit]("checkEmpty")
 
 checkEmpty := {
   val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
-  val lines = Source.fromFile(args(0)).getLines
+  val lines = Source.fromFile(args(0)).getLines.filter(_.nonEmpty)
 
   if(lines.nonEmpty) sys.error(s"File ${args(0)} is non empty - contents ${lines.toList}") else ()
 }

--- a/src/sbt-test/sbt-directive/basic/test
+++ b/src/sbt-test/sbt-directive/basic/test
@@ -1,7 +1,7 @@
 > compile
 
 # Should generate a source
-$ exists target/directive/generatedSources/hello/HelloWorld.scala
+$ exists target/scala-2.11/src_managed/directive/hello/HelloWorld.scala
 
 # Source should be empty
-> checkEmpty target/directive/generatedSources/hello/HelloWorld.scala
+> checkEmpty target/scala-2.11/src_managed/directive/hello/HelloWorld.scala

--- a/src/sbt-test/sbt-directive/identity/test
+++ b/src/sbt-test/sbt-directive/identity/test
@@ -1,7 +1,7 @@
 > compile
 
 # Should generate a source
-$ exists target/directive/generatedSources/hello/HelloWorld.scala
+$ exists target/scala-2.11/src_managed/directive/hello/HelloWorld.scala
 
 #Source should be the same
-> checkIdentity src/main/scala/hello/HelloWorld.scala target/directive/generatedSources/hello/HelloWorld.scala
+> checkIdentity src/main/scala/hello/HelloWorld.scala target/scala-2.11/src_managed/directive/hello/HelloWorld.scala

--- a/src/sbt-test/sbt-directive/java-sources/checkEmpty.sbt
+++ b/src/sbt-test/sbt-directive/java-sources/checkEmpty.sbt
@@ -4,7 +4,7 @@ val checkEmpty = InputKey[Unit]("checkEmpty")
 
 checkEmpty := {
   val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
-  val lines = Source.fromFile(args(0)).getLines
+  val lines = Source.fromFile(args(0)).getLines.filter(_.nonEmpty)
 
   if(lines.nonEmpty) sys.error(s"File ${args(0)} is non empty - contents ${lines.toList}") else ()
 }

--- a/src/sbt-test/sbt-directive/java-sources/test
+++ b/src/sbt-test/sbt-directive/java-sources/test
@@ -1,7 +1,7 @@
 > compile
 
 # Should generate a source
-$ exists target/directive/generatedSources/hello/HelloWorld.java
+$ exists target/scala-2.11/src_managed/directive/hello/HelloWorld.java
 
 # Source should be empty
-> checkEmpty target/directive/generatedSources/hello/HelloWorld.java
+> checkEmpty target/scala-2.11/src_managed/directive/hello/HelloWorld.java

--- a/src/sbt-test/sbt-directive/multi-module/checkEmpty.sbt
+++ b/src/sbt-test/sbt-directive/multi-module/checkEmpty.sbt
@@ -4,7 +4,7 @@ val checkEmpty = InputKey[Unit]("checkEmpty")
 
 checkEmpty := {
   val args: Seq[String] = Def.spaceDelimited("<arg>").parsed
-  val lines = Source.fromFile(args(0)).getLines
+  val lines = Source.fromFile(args(0)).getLines.filter(_.nonEmpty)
 
   if(lines.nonEmpty) sys.error(s"File ${args(0)} is non empty - contents ${lines.toList}") else ()
 }

--- a/src/sbt-test/sbt-directive/multi-module/test
+++ b/src/sbt-test/sbt-directive/multi-module/test
@@ -1,10 +1,10 @@
 > compile
 
 # Should generate a source for kernel
-$ exists kernel/target/directive/generatedSources/multimodule/kernel.scala
+$ exists kernel/target/scala-2.11/src_managed/directive/multimodule/kernel.scala
 
 # Source should be empty
-> checkEmpty kernel/target/directive/generatedSources/multimodule/kernel.scala
+> checkEmpty kernel/target/scala-2.11/src_managed/directive/multimodule/kernel.scala
 
 # Should not generate a source for core
--$ exists core/target/directive/generatedSources/multimodule/core.scala
+-$ exists core/target/scala-2.11/src_managed/directive/multimodule/core.scala


### PR DESCRIPTION
Putting generated sources in `sourceManaged`.
Adding `sourceManaged` as to compile `sourceDirectories` for `scoverage`.
Fixing the `strip` preprocessor to replace lines with empty lines.
